### PR TITLE
Upgrade elm/http to 2.0.0

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -10,8 +10,8 @@
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
         "elm/core": "1.0.0 <= v < 2.0.0",
-        "elm/http": "1.0.0 <= v < 2.0.0",
-        "elm/json": "1.0.0 <= v < 2.0.0"
+        "elm/http": "2.0.0 <= v < 3.0.0",
+        "elm/json": "1.1.0 <= v < 2.0.0"
     },
     "test-dependencies": {}
 }

--- a/examples/elm.json
+++ b/examples/elm.json
@@ -8,12 +8,14 @@
     "dependencies": {
         "direct": {
             "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
+            "elm/core": "1.0.1",
             "elm/html": "1.0.0",
-            "elm/http": "1.0.0",
-            "elm/json": "1.0.0"
+            "elm/http": "2.0.0",
+            "elm/json": "1.1.3"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
+            "elm/file": "1.0.4",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.0"


### PR DESCRIPTION
This updates our dependency on `elm/http` to `2.0.0`.

The logic I added in `resolveJsonResponse` felt a bit boilerplate-ish. I wonder if I could have pulled that from somewhere else, or if there was another way of creating a task with `2.0`.