### PR TITLE
Separate the Config from the Model so the URL can change over time

### DIFF
--- a/examples/Main.elm
+++ b/examples/Main.elm
@@ -9,7 +9,7 @@ import SweetPoll
 type alias Model =
     { data : Maybe String
     , error : Maybe String
-    , sweetPoll : SweetPoll.Model String
+    , sweetPoll : SweetPoll.PollingState String
     }
 
 
@@ -22,7 +22,7 @@ main =
                 -- From http://tiny.cc/currenttime
                 "https://script.google.com/macros/s/AKfycbyd5AcbAnWi2Yn0xhFRbyzS4qMq1VucMVgVvhul5XqS9HkAyJY/exec"
 
-        sweetPollInit =
+        ( initialPollingState, initialCmd ) =
             SweetPoll.init config
     in
     Browser.element
@@ -30,15 +30,15 @@ main =
             \_ ->
                 ( { data = Nothing
                   , error = Nothing
-                  , sweetPoll = sweetPollInit |> Tuple.first
+                  , sweetPoll = initialPollingState
                   }
-                , sweetPollInit |> Tuple.second
+                , initialCmd
                 )
         , update =
             \action model ->
-                case SweetPoll.update action model.sweetPoll of
-                    { sweetPollModel, newData, error, cmd } ->
-                        ( { sweetPoll = sweetPollModel
+                case SweetPoll.update config action model.sweetPoll of
+                    { newState, newData, error, cmd } ->
+                        ( { sweetPoll = newState
                           , data = newData
                           , error = error |> Maybe.map Debug.toString
                           }


### PR DESCRIPTION
Note that I'm keeping the changes minimal because the tests have not been revived after the Elm 0.19 upgrade (WIP https://github.com/NoRedInk/elm-sweet-poll/pull/6)

It's necessary to allow for the URL to be changed over time so that I can implement polling that sends the "last poll time" as a URL parameter.  Separating the config from the polling state is also in line with the pattern recommended by Evan in his elm-sortable-table example https://github.com/evancz/elm-sortable-table#usage-rules